### PR TITLE
Update oauth2.js - Handle Custom URI Scheme Case

### DIFF
--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -72,7 +72,7 @@ module.exports = function(config)
 			authorize_url += `&state=${state}`;
 		}
 
-		win.webContents.on('did-navigate', async (event, url, httpResponseCode, statusText) => 
+		win.webContents.on('will-redirect', async (event, url, httpResponseCode, statusText) => 
 		{
 			if(url.startsWith(redirect_uri))
 			{


### PR DESCRIPTION
`will-redirect` event is much useful, it will not only handle client-side redirection but will also manage server-side 301/302 redirections. `did-navigate` will fail when redirect URL contains custom scheme or protocol (electron will return invalid URL error)